### PR TITLE
Typo in Squad_Engines.cfg

### DIFF
--- a/GameData/TweakScale/patches/Squad/Squad_Engines.cfg
+++ b/GameData/TweakScale/patches/Squad/Squad_Engines.cfg
@@ -264,7 +264,7 @@
     }
 }
 
-@PART[radialEngineMini_v2] for KSP >= 1.7
+@PART[radialEngineMini_v2] // for KSP >= 1.7
 {
     #@TWEAKSCALEBEHAVIOR[Engine]/MODULE[TweakScale] { }
     %MODULE[TweakScale]


### PR DESCRIPTION
Comment on a line was missing leading '//' causing patch to be skipped. 
Affected radialEngineMini_v2